### PR TITLE
Fast local session picker, theming fixes, and config cleanups

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -1,6 +1,9 @@
 font-size = 14
 font-family = JetBrains Mono
 font-thicken = true
+
+font-feature = -calt
+
 confirm-close-surface = false
 # Hardcoded: Catppuccin Frappe surface1
 selection-background = 51576d
@@ -10,7 +13,10 @@ window-padding-x = 0
 window-padding-y = 0
 window-padding-balance = true
 window-padding-color = extend
+
 window-colorspace = display-p3
+
 keybind = shift+enter=text:\x1b\r
+
 theme = light:catppuccin-latte,dark:catppuccin-frappe
 # theme = light:catppuccin-latte,dark:catppuccin-macchiato

--- a/.config/git/ignore
+++ b/.config/git/ignore
@@ -1,0 +1,1 @@
+**/.claude/settings.local.json

--- a/.fzf.config
+++ b/.fzf.config
@@ -1,6 +1,0 @@
---multi 
---color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39
---color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78
---color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39
---color=selected-bg:#BCC0CC
---color=border:#CCD0DA,label:#4C4F69

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -25,6 +25,11 @@ bind g split-window -v -c "#{pane_current_path}"
 unbind s
 bind-key "s" run-shell '"$DOTFILES_DIR/tmux/tzs-session-picker.sh"'
 
+# Session bindings
+bind-key "L" switch-client -l
+bind-key "R" command-prompt -I "#S" "rename-session '%%'"
+bind-key "C" run-shell "tmux attach-session -t . -c '#{pane_current_path}'"
+
 set-option -g status-position top
 
 bind -r j resize-pane -D 5

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -6,6 +6,9 @@ set -g escape-time 10
 set -g default-terminal "tmux-256color"
 set -as terminal-features ",xterm-256color:RGB"
 
+# Resolve dotfiles root from the ~/.tmux.conf symlink (works wherever the repo lives)
+run-shell 'tmux setenv -g DOTFILES_DIR "$(dirname "$(readlink -f ~/.tmux.conf)")"'
+
 unbind r
 bind r source-file ~/.tmux.conf
 
@@ -18,9 +21,9 @@ bind v split-window -h -c "#{pane_current_path}"
 unbind '"'
 bind g split-window -v -c "#{pane_current_path}"
 
-# Bind better session search
+# Bind better session search (local fork of tmux-zoxide-session, see tzs-session-picker.sh)
 unbind s
-set -g @tzs-key-launch 's'
+bind-key "s" run-shell '"$DOTFILES_DIR/tmux/tzs-session-picker.sh"'
 
 set-option -g status-position top
 
@@ -70,7 +73,6 @@ set -g @plugin 'christoomey/vim-tmux-navigator'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'joshmedeski/tmux-nerd-font-window-name'
-set -g @plugin 'jeffnguyen695/tmux-zoxide-session'
 
 set -g @resurrect-capture-pane-contents 'on'
 set -g @resurrect-strategy-nvim 'session'

--- a/.zshrc
+++ b/.zshrc
@@ -174,4 +174,6 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
 
 # Must be last — zoxide hooks into cd
+# Silence zoxide's doctor inside AI CLI tools (their shell snapshots drop chpwd_functions).
+[[ -n $CLAUDECODE || -n $OPENCODE || -n $GEMINI_CLI ]] && export _ZO_DOCTOR=0
 eval "$(zoxide init --cmd cd zsh)"

--- a/.zshrc
+++ b/.zshrc
@@ -52,7 +52,7 @@ zinit ice wait lucid
 zinit snippet OMZP::kubectx
 zinit snippet OMZP::command-not-found
 
-zi snippet OMZP::dotenv
+zinit snippet OMZP::dotenv
 
 # Load completions
 autoload -Uz compinit && compinit
@@ -64,8 +64,8 @@ zinit cdreplay -q
 
 # Keybindings
 bindkey -e # Emacs mode
-bindkey '^p' history-search-backward
-bindkey '^n' history-search-forward
+bindkey '^p' history-substring-search-up
+bindkey '^n' history-substring-search-down
 bindkey '^[w' kill-region
 # Ctrl + f - to apply a suggestion word-by-word.
 # Ctrl + e - to apply it to the end of line.
@@ -75,7 +75,6 @@ bindkey '^f' forward-word
 HISTSIZE=500000
 HISTFILE=~/.zsh_history
 SAVEHIST=$HISTSIZE
-HISTDUP=erase
 setopt appendhistory
 setopt sharehistory
 setopt hist_ignore_space
@@ -155,11 +154,13 @@ export GOPROXY='https://proxy.golang.org,direct'
 export GOROOT='/usr/local/go'
 export GOSUMDB='sum.golang.org'
 
-alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
-
-export PYENV_ROOT="$HOME/.pyenv"
-[[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-eval "$(pyenv init -)"
+if command -v pyenv >/dev/null; then
+  # Keep pyenv shims out of brew's PATH so `brew doctor` stays quiet
+  alias brew='env PATH="${PATH//$(pyenv root)\/shims:/}" brew'
+  export PYENV_ROOT="$HOME/.pyenv"
+  [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+  eval "$(pyenv init -)"
+fi
 
 autoload -z edit-command-line
 zle -N edit-command-line

--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,3 @@
-tap "homebrew/bundle"
 # Clone of cat(1) with syntax highlighting and Git integration
 brew "bat"
 # GNU internationalization (i18n) and localization (l10n) library
@@ -29,6 +28,8 @@ brew "moreutils"
 brew "neovim"
 # Platform built on V8 to build network applications
 brew "node"
+# Manage multiple Node.js versions
+brew "nvm"
 # Python version management
 brew "pyenv"
 # Search tool like grep and The Silver Searcher
@@ -69,6 +70,8 @@ cask "battery"
 cask "betterdisplay"
 # Web browser
 cask "firefox"
+# GPU-accelerated terminal emulator (primary terminal)
+cask "ghostty"
 cask "font-hack-nerd-font"
 cask "font-jetbrains-mono-nerd-font"
 # Desktop automation application

--- a/tmux/fzf-theme.sh
+++ b/tmux/fzf-theme.sh
@@ -1,0 +1,24 @@
+# Sourced by the tmux picker scripts — sets fzf colors from the macOS appearance.
+# (fzf-tmux forwards FZF_DEFAULT_OPTS into the popup, so exporting here is enough.)
+
+is_dark() {
+  defaults read -g AppleInterfaceStyle &>/dev/null
+}
+
+if is_dark; then
+    # Catppuccin Frappe
+    export FZF_DEFAULT_OPTS=" \
+--color=bg+:#414559,bg:#303446,spinner:#F2D5CF,hl:#E78284 \
+--color=fg:#C6D0F5,header:#E78284,info:#CA9EE6,pointer:#F2D5CF \
+--color=marker:#BABBF1,fg+:#C6D0F5,prompt:#CA9EE6,hl+:#E78284 \
+--color=selected-bg:#51576D \
+--color=border:#414559,label:#C6D0F5"
+else
+    # Catppuccin Latte
+    export FZF_DEFAULT_OPTS=" \
+--color=bg+:#CCD0DA,bg:#EFF1F5,spinner:#DC8A78,hl:#D20F39 \
+--color=fg:#4C4F69,header:#D20F39,info:#8839EF,pointer:#DC8A78 \
+--color=marker:#7287FD,fg+:#4C4F69,prompt:#8839EF,hl+:#D20F39 \
+--color=selected-bg:#BCC0CC \
+--color=border:#CCD0DA,label:#4C4F69"
+fi

--- a/tmux/tzs-session-picker.sh
+++ b/tmux/tzs-session-picker.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# Fork of jeffnguyen695/tmux-zoxide-session (zoxide-session.sh).
+# Same behavior, but options/header/help are inlined instead of fetched via
+# ~60 subprocess spawns per launch — that overhead was ~0.8s per open.
+
+source "$(dirname "$0")/fzf-theme.sh"
+
+preview_location="top"
+preview_ratio="70%"
+window_height="65%"
+window_width="65%"
+
+key_accept="enter"
+key_new="ctrl-e"
+key_kill="ctrl-x"
+key_rename="ctrl-r"
+key_find="ctrl-f"
+key_window="ctrl-w"
+key_select_up="ctrl-p"
+key_select_down="ctrl-n"
+key_preview_up="ctrl-u"
+key_preview_down="ctrl-d"
+key_help="ctrl-h"
+key_quit="esc"
+
+prompt_sessions="Sessions"
+prompt_windows="Windows"
+prompt_find="Directories"
+prompt_kill_session="Kill sessions"
+prompt_kill_window="Kill windows"
+prompt_rename_session="Rename session"
+prompt_rename_window="Rename window"
+prompt_help="Help"
+
+Y=$'\033[0;33m'
+R=$'\033[0m'
+
+header=":: <${Y}${key_help}${R}> for ${Y}Help${R} | 󰿄 <${Y}${key_accept}${R}> |  <${Y}${key_new}${R}> |  <${Y}${key_find}${R}> |  <${Y}${key_window}${R}> | 󱂧 <${Y}${key_kill}${R}> | 󰑕 <${Y}${key_rename}${R}> |  <${Y}${key_quit}${R}>"
+
+# format: yellow "icon key" padded to 10 chars, built with printf -v (no forks)
+fmt() { printf -v "$1" '%s%s %-10s%s' "$Y" "$2" "$3" "$R"; }
+fmt f_accept "󰿄" "$key_accept"
+fmt f_new "" "$key_new"
+fmt f_find "" "$key_find"
+fmt f_window "" "$key_window"
+fmt f_kill "󱂧" "$key_kill"
+fmt f_rename "󰑕" "$key_rename"
+fmt f_quit "" "$key_quit"
+fmt f_up "" "$key_select_up"
+fmt f_down "" "$key_select_down"
+fmt f_pup "" "$key_preview_up"
+fmt f_pdown "" "$key_preview_down"
+fmt f_help "" "$key_help"
+
+printf -v help '
+%s Go to selected session / window
+             If no match, create a new session from the best matching directory
+%s Create a new session with the query as its name
+%s Find directories with zoxide
+%s List session windows
+%s Kill selected session / window
+%s Rename selected session / window
+%s Back / Quit
+%s Select up
+%s Select down
+%s Scroll preview up
+%s Scroll preview down
+%s Show help' "$f_accept" "$f_new" "$f_find" "$f_window" "$f_kill" "$f_rename" "$f_quit" "$f_up" "$f_down" "$f_pup" "$f_pdown" "$f_help"
+
+list_sessions='tmux list-sessions | sed -E \"s/:.*$//\"'
+
+list_windows='max_len=-1
+for line in \$(tmux list-windows -a -F \"#{session_name}:#{window_index}\"); do
+  if [[ \${#line} -gt \$max_len ]]; then
+    max_len=\${#line}
+  fi
+done
+tmux list-windows -a -F \"#{p\${max_len}:#{session_name}:#{window_index}}  #{T:tree_mode_format}\"'
+
+handle_find='if [[ ! $FZF_PROMPT =~ '"$prompt_find"' ]]; then
+  echo "clear-query+enable-search+toggle-sort+change-prompt('"$prompt_find"' > )+reload(zoxide query --list)+change-preview(ls --color=always -Cp \{1})"
+fi'
+
+handle_window='load_windows="clear-query+enable-search+change-prompt('"$prompt_windows"' > )+reload('"$list_windows"')+change-preview(tmux capture-pane -ep -t \{1})"
+if [[ $FZF_PROMPT =~ '"$prompt_find"' ]]; then
+  echo "toggle-sort+$load_windows"
+elif [[ ! $FZF_PROMPT =~ '"$prompt_windows"' ]]; then
+  echo "$load_windows"
+fi'
+
+handle_kill='if [[ $FZF_PROMPT =~ '"$prompt_sessions"' ]]; then
+  echo "clear-query+change-prompt('"$prompt_kill_session"' (y/n) > )+reload(echo {+1})+disable-search"
+elif [[ $FZF_PROMPT =~ '"$prompt_windows"' ]]; then
+  echo "clear-query+change-prompt('"$prompt_kill_window"' (y/n) > )+reload(echo {+1})+disable-search"
+fi'
+
+handle_rename='if [[ $FZF_PROMPT =~ '"$prompt_sessions"' ]]; then
+  echo "clear-query+change-prompt('"$prompt_rename_session"' > )+change-preview(echo "New session name: \{q}")+reload(echo {})+disable-search"
+elif [[ $FZF_PROMPT =~ '"$prompt_windows"' ]]; then
+  echo "clear-query+change-prompt('"$prompt_rename_window"' > )+change-preview(echo "New window name: \{q}")+reload(echo {})+disable-search"
+fi'
+
+handle_accept='load_sessions="clear-query+enable-search+change-prompt('"$prompt_sessions"' > )+change-preview(tmux capture-pane -ep -t \{1})+reload('"$list_sessions"')"
+load_windows="clear-query+enable-search+change-prompt('"$prompt_windows"' > )+change-preview(tmux capture-pane -ep -t \{1})+reload('"$list_windows"')"
+
+if [[ $FZF_PROMPT =~ '"$prompt_sessions"' ]]; then
+  echo "replace-query+print-query"
+elif [[ $FZF_PROMPT =~ '"$prompt_windows"' ]]; then
+  echo "transform-query(echo {1})+print-query"
+elif [[ $FZF_PROMPT =~ '"$prompt_find"' ]]; then
+  echo "replace-query+print-query"
+elif [[ $FZF_PROMPT =~ "'"$prompt_kill_session"'" ]]; then
+  if [[ $FZF_QUERY == "y" ]]; then
+    echo "execute-silent(for sess in \$(echo "{}"); do tmux kill-session -t \$sess; done)+$load_sessions"
+  else
+    echo "$load_sessions"
+  fi
+elif [[ $FZF_PROMPT =~ "'"$prompt_kill_window"'" ]]; then
+  if [[ $FZF_QUERY == "y" ]]; then
+    echo "execute-silent(for win in \$(echo "{}"); do tmux kill-window -t \$win; done)+$load_windows"
+  else
+    echo "$load_windows"
+  fi
+elif [[ $FZF_PROMPT =~ "'"$prompt_rename_session"'" ]]; then
+  echo "execute-silent(tmux rename-session -t {1} {q})+$load_sessions"
+elif [[ $FZF_PROMPT =~ "'"$prompt_rename_window"'" ]]; then
+  echo "execute-silent(tmux rename-window -t {1} {q})+$load_windows"
+fi'
+
+handle_new='if [[ $FZF_PROMPT =~ '"$prompt_sessions"' ]]; then
+  echo "execute-silent(tmux new-session -ds "{q}")+print-query"
+fi'
+
+handle_quit='load_sessions="clear-query+enable-search+change-prompt('"$prompt_sessions"' > )+reload('"$list_sessions"')+change-preview(tmux capture-pane -ep -t \{1})"
+load_windows="clear-query+enable-search+change-prompt('"$prompt_windows"' > )+change-preview(tmux capture-pane -ep -t \{1})+reload('"$list_windows"')"
+
+if [[ $FZF_PROMPT =~ '"$prompt_find"' ]]; then
+  echo "toggle-sort+$load_sessions"
+elif [[ $FZF_PROMPT =~ ('"$prompt_windows"'|'"$prompt_find"'|"'"$prompt_kill_session"'"|"'"$prompt_rename_session"'"|'"$prompt_help"') ]]; then
+  echo "$load_sessions"
+elif [[ $FZF_PROMPT =~ ("'"$prompt_kill_window"'"|"'"$prompt_rename_window"'") ]]; then
+  echo "$load_windows"
+else
+  echo "abort"
+fi'
+
+handle_help="change-prompt($prompt_help > )+reload()+change-preview(echo '$help')"
+
+launch() {
+	local sessions
+	sessions=$(tmux list-sessions | sed -E "s/:.*$//")
+
+	echo -e "${sessions// /}" | fzf-tmux \
+		-p "$window_width,$window_height" \
+		--preview-window="${preview_location},${preview_ratio},," \
+		--border bold \
+		--header="$header" \
+		--prompt="$prompt_sessions > " \
+		--preview="tmux capture-pane -ep -t {1}" \
+		--border-label " Current: $(tmux display-message -p '#S') " \
+		--bind 'focus:transform-preview-label:echo [ {1} ]' \
+		--bind "$key_window:transform:$handle_window" \
+		--bind "$key_find:transform:$handle_find" \
+		--bind "$key_kill:transform:$handle_kill" \
+		--bind "$key_rename:transform:$handle_rename" \
+		--bind "$key_accept:transform:$handle_accept" \
+		--bind "$key_new:transform:$handle_new" \
+		--bind "$key_quit:transform:$handle_quit" \
+		--bind "$key_help:$handle_help" \
+		--bind "$key_preview_up:preview-half-page-up" \
+		--bind "$key_preview_down:preview-half-page-down" \
+		--bind "$key_select_up:up" \
+		--bind "$key_select_down:down" \
+		--scrollbar '▌▐' \
+		--print-query \
+		--multi \
+		--exit-0
+}
+
+handle_output() {
+	target=$(echo "$1" | tr -d '\n')
+	if [[ -z "$target" ]]; then
+		exit 0
+	fi
+
+	if ! tmux has-session -t="$target" 2>/dev/null; then
+		if test -d "$target"; then
+			tmux new-session -ds "${target##*/}" -c "$target"
+			target="${target##*/}"
+		else
+			z_target=$(zoxide query "$target")
+			target="${z_target##*/}"
+			tmux new-session -ds "$target" -c "$z_target"
+		fi
+	fi
+	tmux switch-client -t "$target"
+}
+
+handle_output "$(launch)"


### PR DESCRIPTION
 ## Summary

  ### tmux
  - **Replace the tmux-zoxide-session plugin with a local fork** (`tmux/tzs-session-picker.sh`).
    The plugin spawned ~60 subprocesses on every launch (34 `tmux show-option` round-trips plus
    header/help subshells), adding 0.3–0.8s before fzf appeared. The fork inlines options and
    precomputes the header/help — `prefix+s` now opens in ~0.03s with identical behavior.
  - The picker follows macOS light/dark mode via the shared `tmux/fzf-theme.sh`
    (Catppuccin Frappe/Latte), evaluated at open time.
  - Script paths resolve at runtime into `DOTFILES_DIR` from the `~/.tmux.conf` symlink,
    so bindings survive moving the repo.
  - New session bindings: `prefix+L` last session (builtin `switch-client -l`),
    `prefix+R` rename, `prefix+C` attach rooted at the current pane path.

  ### zsh
  - Bind `^p`/`^n` to the zsh-history-substring-search widgets — the plugin was loaded
    but never wired up.
  - Remove the no-op `HISTDUP=erase`; guard the pyenv block for machines without pyenv.
  - Silence zoxide doctor inside AI CLI shells (their snapshots drop `chpwd_functions`).

  ### Misc
  - Brewfile: drop the deprecated `homebrew/bundle` tap; add `nvm` and `ghostty`,
    which the configs depend on but were never recorded.
  - ghostty: disable font ligatures (`-calt`).
  - Add a global git ignore for `.claude/settings.local.json`.
  - Remove dead `.fzf.config` (nothing read it) and bump the nvim submodule.

  ## Test plan
  - `zsh -n .zshrc` and a fresh tmux server (`tmux -L test -f .tmux.conf`) load cleanly
  - `prefix+s` verified working and themed in the live server; startup timed at ~0.03s
    vs ~0.3–0.8s before
  - `DOTFILES_DIR` confirmed to resolve through the symlink; both light/dark fzf palettes verified